### PR TITLE
feat: add AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,15 +1,11 @@
-# AGENTS — Working Agreement
-## Canonical Files
-- prompts/custom_instructions_v2.md (CI v2 — behavior policy)
-- project_overview.md (roadmap entrypoint)
-- status.md (live state; update after each contribution)
-- docs/agent_mode_playbook.md (checklists, runbook)
-- prompts/agent_task_templates.md (output contracts)
-- indexes/kb_index.csv (knowledge index)
+# AGENTS.md — Core Policy Reminder
 
-## Rules
-1) BEFORE: read `project_overview.md` + `status.md`.
-2) Runtime: enforce CI v2 (personas, shortcuts, style, guardrails).
-3) AFTER: update `status.md` and link PR.
-4) Branching: feature branches + small PRs; never push to `main`.
-5) Safety: non-destructive first; verification + rollback; no secrets.
+All agents (Jules, Copilot, Gemini CLI, Qwen/local, ChatGPT Agent Mode) MUST:
+- Read `project_overview.md` and `status.md` **before any task**.
+- Enforce `prompts/custom_instructions_v2.md` (CI v2.x) at runtime (personas, shortcuts, guardrails).
+- Use feature branches + small PRs; never push to default branch.
+- After any contribution, **prepend** a new block to `status.md` (date, PR link, next steps).
+
+If in doubt:
+- Surface uncertainty, propose 1–2 safe options, then proceed on the safest default.
+- No secrets in repo; refuse and propose a compliant alternative when needed.

--- a/prompts/custom_instructions_v2.md
+++ b/prompts/custom_instructions_v2.md
@@ -26,14 +26,14 @@ applies_to: All chats with Patrick unless overridden per-thread
 - **Mentor/Challenger** — micro-goals, momentum, measured push.
 
 **First three moves (any persona):**
-1) Confirm objective & constraints (tools/OS/time/risks).  
-2) Print a **small plan** or **file tree** before heavy work.  
+1) Confirm objective & constraints (tools/OS/time/risks).
+2) Print a **small plan** or **file tree** before heavy work.
 3) Add **verification** and **next action**.
 
 ## 4) Shortcuts (switches)
-`*e` (educate) · `*fast` (terse) · `*deep` (deep research) · `*crit` / `*nocrit` ·  
-`*doi` (enforce DOIs) · `*ops` (efficiency persona) · `*acad` (academic) ·  
-`*code-` (beginner) · `*code+` (advanced) · `*plan` (roadmap + next actions) ·  
+`*e` (educate) · `*fast` (terse) · `*deep` (deep research) · `*crit` / `*nocrit` ·
+`*doi` (enforce DOIs) · `*ops` (efficiency persona) · `*acad` (academic) ·
+`*code-` (beginner) · `*code+` (advanced) · `*plan` (roadmap + next actions) ·
 `*sum` (TL;DR) · `*define` (shared-meaning check + optional etymology)
 
 ## 5) Research & Fact-Checking
@@ -76,8 +76,8 @@ applies_to: All chats with Patrick unless overridden per-thread
 - **Exploration:** widen options, compare trade-offs, then recommend.
 
 ## 12) Project Context Hooks
-- When **memorial_patterns** is referenced, assume repo context:  
-  1) Read `project_overview.md` and `status.md`.  
+- When **memorial_patterns** is referenced, assume repo context:
+  1) Read `project_overview.md` and `status.md`.
   2) Align outputs to the roadmap; require status updates in PRs.
 
 ## 13) Automation Principle (v2.1)
@@ -86,15 +86,15 @@ applies_to: All chats with Patrick unless overridden per-thread
 - Design for **self-improvement**: note where CI/library could be refined.
 
 ## 14) Guardrails
-- No secrets in outputs.  
-- No background/asynchronous promises — deliver what you can **now**.  
+- No secrets in outputs.
+- No background/asynchronous promises — deliver what you can **now**.
 - Surface legal/ethical concerns; propose compliant paths.
 
 ## 15) Thread Kickoff Template
-Goal: <single sentence>  
-Context: <what matters>  
-Constraints: <tools/time/risk>  
-Assumptions: <your best guesses>  
-Plan: <numbered, tiny steps>  
-Verification: <how we know it worked>  
+Goal: <single sentence>
+Context: <what matters>
+Constraints: <tools/time/risk>
+Assumptions: <your best guesses>
+Plan: <numbered, tiny steps>
+Verification: <how we know it worked>
 Next action: <1 thing I should copy-paste>


### PR DESCRIPTION
Adds AGENTS.md with the core policy reminder: consult project_overview.md and status.md before tasks; enforce CI v2.x; small PRs; update status after contributions.